### PR TITLE
Benchmark GO STF on aarch64 via `wasmer`, `wasmtime` (llvm/cranelift) and directly

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,7 +65,7 @@ RUN apt update && apt install -y git build-essential ninja-build pkg-config libg
 RUN git clone https://git.qemu.org/git/qemu.git && \
     cd qemu && \
     sed -i 's/g_assert(count > 0)/g_assert(count >= 0)/g' tests/tcg/plugins/insn.c && \
-    ./configure --target-list=riscv64-linux-user,riscv64-softmmu --enable-plugins && \
+    ./configure --target-list=riscv64-linux-user,riscv64-softmmu,x86_64-softmmu,i386-softmmu,x86_64-linux-user,i386-linux-user,aarch64-softmmu,aarch64-linux-user --enable-plugins && \
     make -j4 && \
     make install && \
     cp build/tests/tcg/plugins/libinsn.so /libinsn.so && \
@@ -116,14 +116,26 @@ RUN git clone https://github.com/psilva261/wasm-micro-runtime-zkvm.git /opt/wamr
     cmake . && \
     make
 
+RUN apt update && apt install -y gcc-riscv64-linux-gnu
+RUN apt update && apt install -y wget
+
+RUN wget https://wasmtime.dev/install.sh \
+    && chmod u+x install.sh \
+    && ./install.sh --version v39.0.1 \
+    && rm ./install.sh
+
+RUN curl https://get.wasmer.io -sSfL | sh -s "v6.1.0"
+
+RUN git clone https://github.com/richfelker/musl-cross-make \
+    && cd musl-cross-make \
+    && printf 'TARGET = aarch64-linux-musl\nOUTPUT = /opt/aarch64-linux-musl-gcc\n' > config.mak \
+    && make -j8 \
+    && make install \
+    && cd .. \
+    && rm -r musl-cross-make
+
 # Add toolchains to PATH
 ENV PATH="/opt/riscv-newlib/bin:/opt/w2c2/w2c2:/opt/wamr/wamr-compiler:${PATH}"
-
-RUN apt update && apt install -y gcc-riscv64-linux-gnu
-
-RUN curl https://wasmtime.dev/install.sh -sSf | bash
-
-RUN curl https://get.wasmer.io -sSfL | sh
 
 # Set working directory
 WORKDIR /workspace

--- a/examples/build-wasm/go/.cargo/config.toml
+++ b/examples/build-wasm/go/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.riscv64gc-unknown-linux-gnu]
 linker = "riscv64-linux-gnu-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-gnu-gcc"

--- a/go_benchmark_aarch64.sh
+++ b/go_benchmark_aarch64.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+echo "" > go_benchmark_results_aarch64.txt
+
+rustup target add aarch64-unknown-linux-musl
+rustup component add rust-std-aarch64-unknown-linux-musl
+
+echo "Translating Go to WASM..."
+
+./examples/scripts/go2wasm.sh
+
+echo "Transpiling WASM to CWASM with wasmtime..."
+
+./docker/docker-shell.sh /root/.wasmtime/bin/wasmtime compile --target aarch64-unknown-linux-musl  examples/build-wasm/go/stateless.wasm -o examples/build-wasm/go/stateless-by-wasmtime/src/stateless.cwasm
+(cd examples/build-wasm/go/stateless-by-wasmtime/; RUSTFLAGS='-C target-feature=+crt-static -C link-arg=-static'   cargo build --release --target aarch64-unknown-linux-musl)
+./docker/docker-shell.sh qemu-aarch64 -plugin /libinsn.so examples/build-wasm/go/stateless-by-wasmtime/target/aarch64-unknown-linux-musl/release/standalone >> go_benchmark_results_aarch64.txt 2>&1
+
+echo "Transpiling WASM to WASMU with wasmer(cranelift)..."
+
+./docker/docker-shell.sh /root/.wasmer/bin/wasmer compile --cranelift --target aarch64-unknown-linux-musl  examples/build-wasm/go/stateless.wasm -o examples/build-wasm/go/stateless-by-wasmer/src/stateless.wasmu
+(cd examples/build-wasm/go/stateless-by-wasmer/; RUSTFLAGS='-C target-feature=+crt-static -C link-arg=-static'   cargo build --release --target aarch64-unknown-linux-musl)
+./docker/docker-shell.sh qemu-aarch64 -plugin /libinsn.so examples/build-wasm/go/stateless-by-wasmer/target/aarch64-unknown-linux-musl/release/standalone >> go_benchmark_results_aarch64.txt 2>&1
+
+echo "Transpiling WASM to WASMU with wasmer(llvm)..."
+
+./docker/docker-shell.sh /root/.wasmer/bin/wasmer compile --llvm --target aarch64-unknown-linux-musl  examples/build-wasm/go/stateless.wasm -o examples/build-wasm/go/stateless-by-wasmer/src/stateless.wasmu
+(cd examples/build-wasm/go/stateless-by-wasmer/; RUSTFLAGS='-C target-feature=+crt-static -C link-arg=-static'   cargo build --release --target aarch64-unknown-linux-musl)
+./docker/docker-shell.sh qemu-aarch64 -plugin /libinsn.so examples/build-wasm/go/stateless-by-wasmer/target/aarch64-unknown-linux-musl/release/standalone >> go_benchmark_results_aarch64.txt 2>&1
+
+echo "Direct compilation..."
+
+(cd examples/go/stateless; GOOS=linux GOARCH=arm64 go build -o ./stateless)
+./docker/docker-shell.sh qemu-aarch64 -plugin /libinsn.so examples/go/stateless/stateless >> go_benchmark_results_aarch64.txt 2>&1
+
+echo "Done"
+


### PR DESCRIPTION
Enable x86 QEMU
Enable AARCH64 QEMU
Build Linux musl aarch64 gcc in docker