### PR TITLE
Disable bounds check for WAMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ See the "Known Issues" section for details.
 
 | Program | w2c2<br>-O0 | w2c2<br>-O3 | wasmtime | wasmer<br>(cranelift) | wasmer<br>(llvm) | WAMR<br>-O0 | WAMR<br>-O3 | directly |
 |---|---|---|---|---|---|---|---|---|
-| `reva-client-eth` (Rust) | 4,543,397,058 | 1,337,696,305 | 1,074,488,397 | doesn't work | ? | didn't check | ? | 388,564,723 |
+| `reva-client-eth` (Rust) | 4,543,397,058 | 1,337,696,305 | 1,074,488,397 | doesn't work | ? | 2,472,559,016 | ? | 388,564,723 |
 | `stateless` (Go) | 6,039,298,186 | 2,154,036,727 | 874,758,419 | 953,874,491 | ? | 3,526,934,350 | ? | 236,265,327 |
 
 ## Analysis

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ See the "Known Issues" section for details.
 | Program | w2c2<br>-O0 | w2c2<br>-O3 | wasmtime | wasmer<br>(cranelift) | wasmer<br>(llvm) | WAMR<br>-O0 | WAMR<br>-O3 | directly |
 |---|---|---|---|---|---|---|---|---|
 | `reva-client-eth` (Rust) | 4,543,397,058 | 1,337,696,305 | 1,074,488,397 | doesn't work | ? | didn't check | ? | 388,564,723 |
-| `stateless` (Go) | 6,039,298,186 | 2,154,036,727 | 874,758,419 | 953,874,491 | ? | 5,427,433,654 | ? | 236,265,327 |
+| `stateless` (Go) | 6,039,298,186 | 2,154,036,727 | 874,758,419 | 953,874,491 | ? | 3,526,934,350 | ? | 236,265,327 |
 
 ## Analysis
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -163,7 +163,7 @@ WORKDIR /tmp
 # https://github.com/llvm/llvm-project/issues/81440
 RUN git clone --branch zkvm https://github.com/psilva261/wasm-micro-runtime-zkvm.git wamr-riscv && \
     cd wamr-riscv && \
-    git checkout e9df4f8169eaafa387b001c0352aec0ea2080ed3 && \
+    git checkout a93ff4cbbf99d35869fac3e03a012e58fc6cfb9c && \
     cmake . \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/opt/wamr-riscv \

--- a/examples/build-wasm/go/stateless-by-wasmer/src/main.rs
+++ b/examples/build-wasm/go/stateless-by-wasmer/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use wasmer::{sys::NativeEngineExt, Engine, Instance, Module, Store};
+use wasmer::{sys::NativeEngineExt, Engine, Function, Instance, Module, Store};
 use wasmer_wasix::{runtime::task_manager::tokio::TokioTaskManager, PluggableRuntime, WasiEnv};
 
 fn main() -> Result<()> {
@@ -41,7 +41,13 @@ fn main() -> Result<()> {
         .finalize(&mut store)?;
 
     // Create imports from WASI
-    let import_object = wasi_env.import_object(&mut store, &module)?;
+    let mut import_object = wasi_env.import_object(&mut store, &module)?;
+
+    let shutdown = Function::new_typed(&mut store, || {
+        println!("shutdown called");
+    });
+
+    import_object.define("testmodule", "shutdown", shutdown);
 
     // Instantiate the module
     let instance = Instance::new(&mut store, &module, &import_object)?;

--- a/examples/build-wasm/go/stateless-by-wasmtime/src/main.rs
+++ b/examples/build-wasm/go/stateless-by-wasmtime/src/main.rs
@@ -5,11 +5,16 @@ fn main() -> anyhow::Result<()> {
     let wasm_bytes = include_bytes!("stateless.cwasm");
 
     let engine = Engine::default();
+
     let module = unsafe { Module::deserialize(&engine, wasm_bytes)? };
 
     // Create linker first
     let mut linker = Linker::new(&engine);
     wasmtime_wasi::p1::add_to_linker_sync(&mut linker, |s| s)?;
+
+    linker.func_wrap("testmodule", "shutdown", || {
+        println!("shutdown called");
+    })?;
 
     // Create WASI context with build_p1()
     let wasi = WasiCtx::builder().inherit_stdio().inherit_args().build_p1();

--- a/examples/go/empty/example.go
+++ b/examples/go/empty/example.go
@@ -1,4 +1,12 @@
 package main
 
+//go:wasmimport testmodule shutdown
+//go:noescape
+func shutdown()
+
 func main() {
+	// During exit a fatal runtime error occurs in WAMR when
+	// compiled with --bounds-check=0. An early shutdown provides
+	// a reliable workaround.
+	shutdown()
 }

--- a/examples/go/empty/example.go
+++ b/examples/go/empty/example.go
@@ -1,9 +1,5 @@
 package main
 
-//go:wasmimport testmodule shutdown
-//go:noescape
-func shutdown()
-
 func main() {
 	// During exit a fatal runtime error occurs in WAMR when
 	// compiled with --bounds-check=0. An early shutdown provides

--- a/examples/go/empty/utils_other.go
+++ b/examples/go/empty/utils_other.go
@@ -1,0 +1,5 @@
+//go:build !wasm
+
+package main
+
+func shutdown() {}

--- a/examples/go/empty/utils_wasm.go
+++ b/examples/go/empty/utils_wasm.go
@@ -1,0 +1,5 @@
+package main
+
+//go:wasmimport testmodule shutdown
+//go:noescape
+func shutdown()

--- a/examples/go/fibonacci/example.go
+++ b/examples/go/fibonacci/example.go
@@ -13,4 +13,9 @@ func main() {
 	n := 20
 	result := fibonacci(n)
 	fmt.Printf("Fibonacci(%d) = %d\n", n, result)
+
+	// During exit a fatal runtime error occurs in WAMR when
+	// compiled with --bounds-check=0. An early shutdown provides
+	// a reliable workaround.
+	shutdown()
 }

--- a/examples/go/fibonacci/utils_other.go
+++ b/examples/go/fibonacci/utils_other.go
@@ -1,0 +1,5 @@
+//go:build !wasm
+
+package main
+
+func shutdown() {}

--- a/examples/go/fibonacci/utils_wasm.go
+++ b/examples/go/fibonacci/utils_wasm.go
@@ -1,0 +1,5 @@
+package main
+
+//go:wasmimport testmodule shutdown
+//go:noescape
+func shutdown()

--- a/examples/go/println/example.go
+++ b/examples/go/println/example.go
@@ -5,6 +5,10 @@ import (
 	"runtime/debug"
 )
 
+//go:wasmimport testmodule shutdown
+//go:noescape
+func shutdown()
+
 func main() {
 	// Limit memory in use. Otherwise when a lot memory is used
 	// eventually the Go runtime will allocate too chunks at
@@ -14,5 +18,12 @@ func main() {
 	debug.SetMemoryLimit(400 * (1 << 20))
 
 	fmt.Println("Hello world from golang")
+
+	// During exit a fatal runtime error occurs in WAMR when
+	// compiled with --bounds-check=0. An early shutdown provides
+	// a reliable workaround.
+	shutdown()
+
 	panic("foo")
+
 }

--- a/examples/go/println/example.go
+++ b/examples/go/println/example.go
@@ -5,10 +5,6 @@ import (
 	"runtime/debug"
 )
 
-//go:wasmimport testmodule shutdown
-//go:noescape
-func shutdown()
-
 func main() {
 	// Limit memory in use. Otherwise when a lot memory is used
 	// eventually the Go runtime will allocate too chunks at

--- a/examples/go/println/utils_other.go
+++ b/examples/go/println/utils_other.go
@@ -1,0 +1,5 @@
+//go:build !wasm
+
+package main
+
+func shutdown() {}

--- a/examples/go/println/utils_wasm.go
+++ b/examples/go/println/utils_wasm.go
@@ -1,0 +1,5 @@
+package main
+
+//go:wasmimport testmodule shutdown
+//go:noescape
+func shutdown()

--- a/examples/go/stateless/main.go
+++ b/examples/go/stateless/main.go
@@ -51,6 +51,10 @@ func Read[T any]() T {
 	return result
 }
 
+//go:wasmimport testmodule shutdown
+//go:noescape
+func shutdown()
+
 func main() {
 	witnessBytes := Read[[]byte]()
 	fmt.Printf("Read witness (%d bytes)\n", len(witnessBytes))
@@ -110,4 +114,9 @@ func main() {
 	if receiptRoot == (common.Hash{}) {
 		panic("Receipt root is empty")
 	}
+
+	// During exit a fatal runtime error occurs in WAMR when
+	// compiled with --bounds-check=0. An early shutdown provides
+	// a reliable workaround.
+	shutdown()
 }

--- a/examples/go/stateless/main.go
+++ b/examples/go/stateless/main.go
@@ -51,10 +51,6 @@ func Read[T any]() T {
 	return result
 }
 
-//go:wasmimport testmodule shutdown
-//go:noescape
-func shutdown()
-
 func main() {
 	witnessBytes := Read[[]byte]()
 	fmt.Printf("Read witness (%d bytes)\n", len(witnessBytes))

--- a/examples/go/stateless/utils_other.go
+++ b/examples/go/stateless/utils_other.go
@@ -1,0 +1,5 @@
+//go:build !wasm
+
+package main
+
+func shutdown() {}

--- a/examples/go/stateless/utils_wasm.go
+++ b/examples/go/stateless/utils_wasm.go
@@ -1,0 +1,5 @@
+package main
+
+//go:wasmimport testmodule shutdown
+//go:noescape
+func shutdown()

--- a/platform/riscv-qemu-user/custom_imports.c
+++ b/platform/riscv-qemu-user/custom_imports.c
@@ -1,0 +1,47 @@
+/* Custom WASM imports for zkvm target
+ *
+ * This file implements custom functions for Go programs using //go:wasmimport.
+ *
+ * This will be used to implement zkvm precompiles and zkvm specific functions that the guest
+ * program needs.
+ *
+ */
+
+#include "w2c2_base.h"
+#include <stdio.h>
+
+U32 testmodule__testfunc(void* instance, U32 a, U32 b) {
+    return 1000*a + b;
+}
+
+U32 testmodule__testfunc2(void* instance, U32 a, U32 b) {
+    return a * b;
+}
+
+int testmodule__printk(void* instance, U32 val) {
+    char buf[12];
+    static const char hex[] = "0123456789abcdef";
+
+    buf[0] = '0';
+    buf[1] = 'x';
+    for (int i = 7; i >= 0; --i) {
+        buf[i+2] = hex[val & 0xF];
+        val >>= 4;
+    }
+    buf[10] = '\n';
+    buf[11] = '\0';
+
+    puts(buf);
+}
+
+void testmodule__shutdown(void* instance) {
+    exit(0);
+}
+
+U32 testmodule__input_data_len(void* instance) {
+    return 0;
+}
+
+U32 testmodule__input_data(void* instance, U32 index) {
+    return 0;
+}

--- a/platform/riscv-qemu-user/scripts/c2riscv-qemu-user.sh
+++ b/platform/riscv-qemu-user/scripts/c2riscv-qemu-user.sh
@@ -93,6 +93,7 @@ INCLUDES=(
 # Source files
 SOURCES=(
     platform/riscv-qemu-user/main.c
+    platform/riscv-qemu-user/custom_imports.c
     "$GUEST_DIR/guest.c"
     $GUEST_DIR/s0*.c
     w2c2/embedded/wasi.c

--- a/platform/riscv-wamr-qemu/scripts/wasm2wamr-qemu.sh
+++ b/platform/riscv-wamr-qemu/scripts/wasm2wamr-qemu.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 # wasm2riscv-wamr-qemu - Compile WASM to WAMR RISC-V QEMU binary
 # Usage: ./platform/riscv-wamr-qemu/scripts/wasm2riscv-wamr-qemu.sh <guest-c-package-dir> <output-elf>
@@ -24,12 +24,12 @@ if [ $# -lt 2 ]; then
     echo "  output-elf           Output RISC-V ELF binary path"
     echo ""
     echo "Example:"
-    echo "  $0 build/.c-packages/println build/bin/println.riscv.elf"
+    echo "  $0 examples/build-wasm/go/println.wasm build/bin/println.wamr.elf"
     echo ""
     echo "To run in QEMU:"
     echo "  ./docker/docker-shell.sh qemu-system-riscv64 -machine virt \\"
     echo "    -m 1024M -d plugin -plugin /libinsn.so \\"
-    echo "    -kernel build/bin/println.riscv.elf -nographic \\"
+    echo "    -kernel build/bin/println.wamr.elf -nographic \\"
     echo "    -semihosting-config enable=on,target=native"
     echo ""
     exit 1
@@ -90,7 +90,7 @@ wamrc \
     --cpu-features='+i,+m,+a' \
     --opt-level=0 \
     --size-level=1 \
-    --bounds-checks=1 \
+    --bounds-checks=0 \
     -o $OUTPUT.riscv64.wamr $1
 
 gcc platform/riscv-wamr-qemu/file2c/file2c.c \
@@ -182,7 +182,7 @@ if [ $? -eq 0 ] && [ -f "$OUTPUT" ]; then
     echo "Size: $SIZE"
     echo ""
     echo "To run in QEMU:"
-    echo "  ./docker/docker-shell.sh qemu-system-riscv64 -machine virt \\"
+    echo "  ./docker-shell.sh qemu-system-riscv64 -machine virt \\"
     echo "    -m 1024M -d plugin -plugin /libinsn.so \\"
     echo "    -kernel $OUTPUT -nographic \\"
     echo "    -semihosting-config enable=on,target=native"

--- a/platform/riscv-wamr-qemu/scripts/wasm2wamr-qemu.sh
+++ b/platform/riscv-wamr-qemu/scripts/wasm2wamr-qemu.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 # wasm2riscv-wamr-qemu - Compile WASM to WAMR RISC-V QEMU binary
 # Usage: ./platform/riscv-wamr-qemu/scripts/wasm2riscv-wamr-qemu.sh <guest-c-package-dir> <output-elf>

--- a/platform/riscv-wamr-qemu/startup.S
+++ b/platform/riscv-wamr-qemu/startup.S
@@ -1,5 +1,6 @@
 .section .text.init
 .global _start
+.global shutdown
 
 _start:
     la sp, _stack_top
@@ -17,6 +18,7 @@ bss_done:
     /* Call main */
     call main
 
+shutdown:
     /* https://github.com/xypron/riscv_test_payload (MIT-licensed) */
     li a7, 0x53525354   # SBI extension: SRST (System Reset)
     li a6, 0            # Function: system reset

--- a/platform/riscv-wamr-qemu/syscalls.c
+++ b/platform/riscv-wamr-qemu/syscalls.c
@@ -1,7 +1,8 @@
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <errno.h>
-#include <unistd.h>
 
 #include "uart.h"
 

--- a/rust_benchmark.sh
+++ b/rust_benchmark.sh
@@ -19,6 +19,10 @@ echo "Transpiling WASM to WASMU with wasmer..."
 # TODO: Cranelift is used for now because LLVM support is buggy. Once LLVM is fixed in wasmer use `--llvm` flag instead of `cranelift`; https://github.com/wasmerio/wasmer/issues/5951#issuecomment-3632904384
 /root/.wasmer/bin/wasmer compile --cranelift --target riscv64gc-unknown-linux-gnu  examples/build-wasm/rust/reva-client-eth.wasm -o examples/build-wasm/rust/reva-client-eth-by-wasmer/src/reva-client-eth.wasmu
 
+echo "Transpiling WASM to WAMR AOT with wamrc..."
+
+./platform/riscv-wamr-qemu/scripts/wasm2wamr-qemu.sh examples/build-wasm/rust/reva-client-eth.wasm build/bin/reva-client-eth.wamr.elf
+
 echo "Compiling C to RISCV..."
 
 OPT_LEVEL="-O0" ./platform/riscv-qemu/scripts/c2riscv-qemu.sh build/c-packages/reva-client-eth/ build/bin/reva-client-eth.riscv.O0.elf
@@ -38,6 +42,7 @@ run_qemu "$success_string" "false" "native"         "examples/rust/reva-client-e
 run_qemu "$success_string" "true"  "w2c2-O0"        "build/bin/reva-client-eth.riscv.O0.elf"
 run_qemu "$success_string" "true"  "w2c2-O3"        "build/bin/reva-client-eth.riscv.O3.elf"
 run_qemu "$success_string" "false" "wasmtime"       "examples/build-wasm/rust/reva-client-eth-by-wasmtime/target/riscv64gc-unknown-linux-gnu/release/standalone"
+run_qemu "$success_string" "true"  "wamr"           "build/bin/reva-client-eth.wamr.elf"
 
 # `reva-client-eth` via `wasmer` does not work for some reason. The root cause is not yet known. The error is:
 # Error: RuntimeError: out of bounds memory access


### PR DESCRIPTION
* Export shutdown function as workaround unclean exit issue
* Reduces no. steps by 35%

Originally `--bounds-check=1` was introduced to allow for a clean exit. Since it creates a performance penalty, here is a workaround based on an explicit `shutdown` call. This seems like a clean option for a quick fix, also since the languages in use do bounds checks anyway.